### PR TITLE
Fix duplicated xmlns in IE 11

### DIFF
--- a/src/svgsaver.js
+++ b/src/svgsaver.js
@@ -82,12 +82,13 @@ export class SvgSaver {
   */
   getHTML (el) {
     const svg = this.cloneSVG(el);
-    
+
     var html = svg.outerHTML;
-    if (html)
+    if (html) {
       return html;
-    
-    svg.removeAttribute("xmlns");
+    }
+
+    svg.removeAttribute('xmlns');
     return (new window.XMLSerializer()).serializeToString(svg);
   }
 

--- a/src/svgsaver.js
+++ b/src/svgsaver.js
@@ -82,7 +82,13 @@ export class SvgSaver {
   */
   getHTML (el) {
     const svg = this.cloneSVG(el);
-    return svg.outerHTML || (new window.XMLSerializer()).serializeToString(svg);
+    
+    var html = svg.outerHTML;
+    if (html)
+      return html;
+    
+    svg.removeAttribute("xmlns");
+    return (new window.XMLSerializer()).serializeToString(svg);
   }
 
   /**


### PR DESCRIPTION
XMLSerializer in IE 11 automatically set the SVG namespace, therefore, created SVG file with `xmlns` declared twice, which is then detected as invalid in IE 11.